### PR TITLE
Fire "onPhoneGapConnectionReady" even if Network Status is unavailable

### DIFF
--- a/Android/Sample/assets/www/phonegap-1.0.0.js
+++ b/Android/Sample/assets/www/phonegap-1.0.0.js
@@ -3685,6 +3685,11 @@ var Connection = function() {
             }            
         },
         function(e) {
+            // should only fire this once
+            if (me._firstRun) {
+                me._firstRun = false;
+                PhoneGap.onPhoneGapConnectionReady.fire();
+            }            
             console.log("Error initializing Network Connection: " + e);
         });
 };

--- a/Android/phonegap-1.0.0.js
+++ b/Android/phonegap-1.0.0.js
@@ -3685,6 +3685,11 @@ var Connection = function() {
             }            
         },
         function(e) {
+            // should only fire this once
+            if (me._firstRun) {
+                me._firstRun = false;
+                PhoneGap.onPhoneGapConnectionReady.fire();
+            }            
             console.log("Error initializing Network Connection: " + e);
         });
 };


### PR DESCRIPTION
If "onPhoneGapConnectionReady" never fires, then "deviceready" never fires.  This might happen if the "Network Status" plugin is not enabled, or if the ACCESS_NETWORK_STATE permission is not requested.

I don't know if this is the right solution, but I do know that it should be possible to create a disconnected app with PhoneGap and the "deviceready" event should still fire.
