### PR TITLE
small fix to getContacts() on the Android sample app

### DIFF
--- a/Android/Sample/assets/www/main.js
+++ b/Android/Sample/assets/www/main.js
@@ -110,7 +110,8 @@ function get_contacts() {
     obj.filter = "";
     obj.multiple = true;
     obj.limit = 5;
-    navigator.service.contacts.find(
+    
+    navigator.contacts.find(
             [ "displayName", "name" ], contacts_success,
             fail, obj);
 }


### PR DESCRIPTION
trying phonegap as of version 1.0.0 reference to navigator.service returns null calling navigator.contacts seems to work
