### PR TITLE
Fixing reference to deprecated contacts find call

### DIFF
--- a/Android/Sample/assets/www/main.js
+++ b/Android/Sample/assets/www/main.js
@@ -110,7 +110,7 @@ function get_contacts() {
     obj.filter = "";
     obj.multiple = true;
     obj.limit = 5;
-    navigator.service.contacts.find(
+    navigator.contacts.find(
             [ "displayName", "name" ], contacts_success,
             fail, obj);
 }


### PR DESCRIPTION
Since the example directory has been removed from phonegap-android I'm fixing this in the phonegap project as well.
