### PR TITLE
Wrong syntax for setMetadata

### DIFF
--- a/doc/cordova_file_file.md.html
+++ b/doc/cordova_file_file.md.html
@@ -987,7 +987,7 @@ function fail() {
 }
 
 // Set the metadata
-entry.setMetadata(success, fail, { "com.apple.MobileBackup", 1});
+entry.setMetadata(success, fail, { "com.apple.MobileBackup": 1});
 </code></pre>
 
 <p><strong>iOS Quirk</strong></p>
@@ -1350,7 +1350,7 @@ function fail() {
 }
 
 // Set the metadata
-entry.setMetadata(success, fail, { "com.apple.MobileBackup", 1});
+entry.setMetadata(success, fail, { "com.apple.MobileBackup": 1});
 </code></pre>
 
 <p><strong>iOS Quirk</strong></p>


### PR DESCRIPTION
The documentation ist wrong:

entry.setMetadata(success, fail, { "com.apple.MobileBackup", 1});

The right syntax should be:

entry.setMetadata(success, fail, { "com.apple.MobileBackup": 1}); 
