### PR TITLE
Change to bash to work on older Ubuntu versions

### DIFF
--- a/lib/android/bin/create
+++ b/lib/android/bin/create
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 #       Licensed to the Apache Software Foundation (ASF) under one
 #       or more contributor license agreements.  See the NOTICE file
 #       distributed with this work for additional information


### PR DESCRIPTION
On Ubuntu 10.10 this scripts works only, if executed in bash.

I don't if there is any harm in changing from `sh` to `bash`, but if there isn't this will probably work better.
