### PR TITLE
Update lib/android/cordova-2.5.0rc1.js - rethrow Error if an error in callback function occured

### DIFF
--- a/lib/android/cordova-2.5.0rc1.js
+++ b/lib/android/cordova-2.5.0rc1.js
@@ -969,6 +969,7 @@ function processMessage(message) {
         console.log("processMessage failed: Message: " + message);
         console.log("processMessage failed: Error: " + e);
         console.log("processMessage failed: Stack: " + e.stack);
+        throw e;
     }
 }
 


### PR DESCRIPTION
If there is some error in a callback function, this error is just logged (console.log) and eaten. There is no way how to react on this errors in application. (Error handling with another logging features, redirecting on special error form, etc.)

Throwing that Error is a good idea - there is no reason to eat it, I think.
