### PR TITLE
Allow spaces in project name

### DIFF
--- a/lib/ios/bin/templates/project/cordova/build
+++ b/lib/ios/bin/templates/project/cordova/build
@@ -43,7 +43,7 @@ cd "$PROJECT_PATH"
 APP=build/$PROJECT_NAME.app
 SDK=`xcodebuild -showsdks | grep Sim | tail -1 | awk '{print $6}'`
 
-xcodebuild -project $PROJECT_NAME.xcodeproj -arch i386 -target $PROJECT_NAME -configuration Debug -sdk $SDK clean build VALID_ARCHS="i386" CONFIGURATION_BUILD_DIR="$PROJECT_PATH/build"
+xcodebuild -project "$PROJECT_NAME.xcodeproj" -arch i386 -target "$PROJECT_NAME" -configuration Debug -sdk $SDK clean build VALID_ARCHS="i386" CONFIGURATION_BUILD_DIR="$PROJECT_PATH/build"
 
 
 


### PR DESCRIPTION
In iOS, small update on the Cordova Template build script to allow white space in Project Name

File:
lib/ios/bin/templates/project/cordova/build
