### PR TITLE
Incorrect step in iOS getting started instructions on docs.phonegap.com

### DIFF
--- a/doc/guide_getting-started_ios_index.md.html
+++ b/doc/guide_getting-started_ios_index.md.html
@@ -165,7 +165,7 @@ The Apple® tools required for building iOS applications run only on the OS X op
 
 <h3>Download Cordova</h3>
 
-<p>Download the latest version of <a class="external" href="http://www.apache.org/dist/cordova/">Apache Cordova</a> from http://www.apache.org/dist/cordova/.  Click on the Download icon and select cordova-X.Y.Z-src.zip to download to your machine. The X, Y and Z represent the version number of Cordova, for example 2.5.0.  The download includes the code for all of the Apache Cordova supported platforms.   </p>
+<p> Download the latest version of <a class="external" href="http://www.apache.org/dist/cordova/">Apache Cordova</a> from http://www.apache.org/dist/cordova/.  Click on the Download icon and select cordova-X.Y.Z-src.zip to download to your machine. The X, Y and Z represent the version number of Cordova, for example 2.5.0.  The download includes the code for all of the Apache Cordova supported platforms.   </p>
 
 <h3>Extract Cordova</h3>
 


### PR DESCRIPTION
This is a totally bogus pull request because there's not a way to
submit an issue for this project (sorry for the cheap hack :)).
This bug concerns docs.phonegap.com, _not_ the code in this GitHub
repo at all. I apologize if I'm in the wrong spot; trying to find my
way in a newfangeldy world. :)

Anyway, there's a bug on the iOS Getting Started instructions that
exist at:

http://docs.phonegap.com/en/2.5.0/guide_getting-started_ios_index.md.html#Getting%20Started%20with%20iOS_install_cordova

It says to download PhoneGap from http://phonegap.com/download, and
you'll get a file called cordova-X.Y.Z-src.zip. However, this is not
the case. You get a file instead called phonegap-2.5.0.zip.

That's pretty minor, but then later on it also says you should be able
to find a cordova-ios.zip therein, which does not exist in the
phonegap bundle.

If you follow the instructions in this document in GitHub, downloading
from http://www.apache.org/dist/cordova/, then the instructions work
fine. So this file doesn't need to be patched, but whatever's powering
docs.phonegap.com does.

I mention this just because it royally screwed me up for several
minutes, and would love to save the next person some trouble.

Thanks.
