### PR TITLE
Replaced -all_load linker flag to -force_load for iOS

### DIFF
--- a/lib/ios/bin/templates/project/__TESTING__.xcodeproj/project.pbxproj
+++ b/lib/ios/bin/templates/project/__TESTING__.xcodeproj/project.pbxproj
@@ -573,7 +573,8 @@
 					"-weak_framework",
 					CoreMedia,
 					"-weak-lSystem",
-					"-all_load",
+					"-force_load",
+					"${TARGET_BUILD_DIR}/libCordova.a",
 					"-Obj-C",
 				);
 				SDKROOT = iphoneos;


### PR DESCRIPTION
all_load is bad practice and breaks other SDKs with Objective-C categories. Here is a description of the problem and why all-load is bad:
http://stackoverflow.com/questions/2906147/what-does-the-all-load-linker-flag-do
