### PR TITLE
Fixes a support issue when serializing ArrayBuffers to base64 prior to iOS 6.0

### DIFF
--- a/doc/cordova_media_media.md.html
+++ b/doc/cordova_media_media.md.html
@@ -1044,6 +1044,15 @@ myMedia.play({ playAudioWhenScreenIsLocked : false })
 </code></pre>
 </li>
 <li>
+<p><strong>playAudioWithSpeaker</strong></p>
+
+<p>Pass in this option to the <strong>play</strong> method to specify whether you want to play the audio of the media file over the loud speaker of the device, even if headphones are plugged in (this defaults to false if not set). e.g:</p>
+
+<pre class="prettyprint"><code>var myMedia = new <a href="cordova_media_media.md.html#Media">Media</a>("http://audio.ibeat.org/content/p1rj1s/p1rj1s_-_rockGuitar.mp3")
+myMedia.play({ playAudioWithSpeaker : true })
+</code></pre>
+</li>
+<li>
 <p><strong>order of file search</strong></p>
 
 <p>When only a file name or simple path is provided, iOS will search in the www for the file and then in the application documents/tmp directory.</p>

--- a/lib/ios/CordovaLib/cordova.ios.js
+++ b/lib/ios/CordovaLib/cordova.ios.js
@@ -836,7 +836,17 @@ function massageArgsJsToNative(args) {
     }
     var ret = [];
     var encodeArrayBufferAs8bitString = function(ab) {
-        return String.fromCharCode.apply(null, new Uint8Array(ab));
+        try{
+            return String.fromCharCode.apply(null, new Uint8Array(ab));
+        }catch(e){
+            //This supports iOS versions prior to 6.0
+            var data = new Uint8Array(ab);
+            var dataArray = [];
+            for (var j = 0, jj = data.length; j < jj; ++j) {
+                dataArray.push(data[j]);
+            }
+            return String.fromCharCode.apply(null, dataArray);
+        }
     };
     var encodeArrayBufferAsBase64 = function(ab) {
         return window.btoa(encodeArrayBufferAs8bitString(ab));

--- a/lib/ios/CordovaLib/cordova.ios.js
+++ b/lib/ios/CordovaLib/cordova.ios.js
@@ -843,7 +843,7 @@ function massageArgsJsToNative(args) {
             var data = new Uint8Array(ab);
             var dataArray = [];
             for (var j = 0, jj = data.length; j < jj; ++j) {
-                dataArray.push(data[j]);
+                dataArray[j] = data[j];
             }
             return String.fromCharCode.apply(null, dataArray);
         }


### PR DESCRIPTION
It seems you can't target Uint8Array with an `.apply` function prior to iOS. This workaround solves both problems as shown here:

https://github.com/mozilla/pdf.js/issues/1820
