### PR TITLE
remove Phonegap = cordova assignment from cordova.js project template.

### DIFF
--- a/lib/android/bin/templates/cordova/lib/cordova.js
+++ b/lib/android/bin/templates/cordova/lib/cordova.js
@@ -606,5 +606,3 @@ else {
             break;
     }
 }
-
-var PhoneGap = cordova;


### PR DESCRIPTION
Removed the last line, which is falsely added to this file. Should only be added to the other cordova.js file that contains the actual cordova js implementation. Maybe something is going wrong in the process of pulling the cordova sources?
