### PR TITLE
remove whitespaces from activity name

### DIFF
--- a/lib/android/bin/create
+++ b/lib/android/bin/create
@@ -38,7 +38,7 @@ VERSION=$(cat "$BUILD_PATH"/VERSION)
 
 PROJECT_PATH="${1:-'./example'}"
 PACKAGE=${2:-"org.apache.cordova.example"}
-ACTIVITY=${3:-"cordovaExample"}
+ACTIVITY=$(echo ${3:-"cordovaExample"} | tr -d ' ')
 
 # clobber any existing example
 if [ -d "$PROJECT_PATH" ]


### PR DESCRIPTION
issue https://issues.apache.org/jira/browse/CB-4198 is produced by whitespaces in the activity name.
This modification removes all whitespaces on activity name, so "Hello World" becomes HelloWorld.
This not only fixes issues in tutorial, but for every activity name with whitespaces.
