### PR TITLE
Check to see if photoData exists before using

### DIFF
--- a/lib/ios/CordovaLib/Classes/CDVContact.m
+++ b/lib/ios/CordovaLib/Classes/CDVContact.m
@@ -1326,6 +1326,10 @@ static NSDictionary* org_apache_cordova_contacts_defaultFields = nil;
 
     if (ABPersonHasImageData(self.record)) {
         CFDataRef photoData = ABPersonCopyImageData(self.record);
+        if (!photoData) {
+            return;
+        }
+        
         NSData* data = (__bridge NSData*)photoData;
         // write to temp directory and store URI in photos array
         // get the temp directory path


### PR DESCRIPTION
A fix for issue CB-5698: https://issues.apache.org/jira/browse/CB-5698

Image files that for one reason cannot be copied will crash. Returning
when photoData returns nil prevents the crash.
